### PR TITLE
[RFR] Fix potential error in routes.php

### DIFF
--- a/features/routes.php
+++ b/features/routes.php
@@ -26,6 +26,10 @@ function spy_check_version(WP_REST_Request $request)
 {
     wp_version_check();
     $currentVersion = get_bloginfo('version');
+    
+    if (!function_exists('get_plugins')) {
+        require_once ABSPATH.'wp-admin/includes/plugin.php';
+    }
     $plugins = get_plugins();
     $versionManager = [
         'blogName' => get_bloginfo('name'),


### PR DESCRIPTION
Function get_plugins does not exist if 'wp-admin/includes/plugin.php' was not required yet.